### PR TITLE
Update xtion_tracker.hpp

### DIFF
--- a/include/skeleton_tracker/xtion_tracker.hpp
+++ b/include/skeleton_tracker/xtion_tracker.hpp
@@ -128,7 +128,7 @@ public:
                  depthMode_.getResolutionY(), depthMode_.getFps(), depthMode_.getPixelFormat());
       }
 
-      depthStream_.setMirroringEnabled(false);
+      depthStream_.setMirroringEnabled(true);// both parameters (depth and color stream) settled as "true", it allows a superposition of video and tracking image not mirrored.
     }
     else
     {


### PR DESCRIPTION
I made an insignificant change, setting the depthStream_ mirroring parameter as "true", in order to don't reflex the image nor the tracking; it is possible to overlay the tracking image with the video or the point cloud. However, with this configuration the depth image is yet mirrored.
